### PR TITLE
Fix clip downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # TwitchClipGrabber
 Easy Windows tool for downloading Twitch clips
 
-# As of September 1, 2024 this tool in its current form will no longer work due to a change in Twitch's API
-
-
 ![Text](https://i.imgur.com/sHKFVRR.png)
 
 -----------------------------------------------------

--- a/Twitch Clip Grabber/Clip.cs
+++ b/Twitch Clip Grabber/Clip.cs
@@ -61,6 +61,5 @@ namespace TwitchClipGrabber
         public int? vod_offset { get; set; }
         public DateTime vod_date { get; set; }
         public Dictionary<string, object> clipDict { get; set; }
-        public string download_url { get; set; }
     }
 }

--- a/Twitch Clip Grabber/ClipManager.cs
+++ b/Twitch Clip Grabber/ClipManager.cs
@@ -34,7 +34,6 @@ namespace TwitchClipGrabber
                 foreach (Clip clip in tempCol.data)
                 {
                     clip.vod_date = start;
-                    clip.download_url = clip.thumbnail_url.Replace(@"-preview-480x272.jpg", ".mp4");
                 }
                 outputCol.data.AddRange(tempCol.data);
                 outputCol.pagination.cursor = tempCol.pagination.cursor;

--- a/Twitch Clip Grabber/Form1.cs
+++ b/Twitch Clip Grabber/Form1.cs
@@ -336,6 +336,12 @@ namespace TwitchClipGrabber
         }
         private async void downloadButton_Click(object sender, EventArgs e)
         {
+            if (listView2.CheckedItems.Count == 0)
+            {
+                MessageBox.Show("Please select at least one clip!");
+                return;
+            }
+
             var pathsQueue = new Queue<string>();
             var downloadQueue = new Queue<Clip>();
             var result = downloadTarget.ShowDialog();
@@ -349,7 +355,10 @@ namespace TwitchClipGrabber
                     var path = Path.Combine(downloadTarget.SelectedPath, UserSettings.FormatFilename(clipCol.data[item.Index], Properties.Settings.Default.FilenameFormat));
                     pathsQueue.Enqueue(path);
                 }
-                await Program.AddToQueue(downloadQueue, pathsQueue);
+                if (downloadQueue.Count > 0)
+                {
+                    await Program.AddToQueue(downloadQueue, pathsQueue);
+                }
             }
         }
         private void preview_Click(object sender, EventArgs e)

--- a/Twitch Clip Grabber/Program.cs
+++ b/Twitch Clip Grabber/Program.cs
@@ -19,6 +19,7 @@ namespace TwitchClipGrabber
         private static Queue<Clip> downloadQueue = new();
         private static Queue<string> pathsQueue = new();
         private static List<string> failedDownloads = new();
+        private static bool isFirstDownload = true;
         private static bool _isDownloading;
         public static bool isDownloading
         {
@@ -40,7 +41,6 @@ namespace TwitchClipGrabber
         {
             clipDownloader.IgnoreDownloadErrors = false;
             clipDownloader.OverwriteFiles = false;
-            Utils.DownloadBinaries();
 
             _ = new Http();
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
@@ -71,6 +71,17 @@ namespace TwitchClipGrabber
         public static async Task AddToQueue(Queue<Clip> queue, Queue<string> paths)
         {
             form1 = Application.OpenForms["Form1"] as Form1;
+
+            if (isFirstDownload)
+            {
+                isFirstDownload = false;
+                form1.progressBar.Value = 0;
+                form1.progressLabel.Text = "Downloading Dependencies";
+                await Utils.DownloadBinaries();
+                form1.progressLabel.Text = "Checking for Dependency Updates";
+                await clipDownloader.RunUpdate();
+            }
+
             queueStartCount += queue.Count;
             foreach (var clip in queue)
             {

--- a/Twitch Clip Grabber/Program.cs
+++ b/Twitch Clip Grabber/Program.cs
@@ -38,6 +38,7 @@ namespace TwitchClipGrabber
         static void Main()
         {
             clipDownloader.IgnoreDownloadErrors = false;
+            clipDownloader.OverwriteFiles = false;
             Utils.DownloadBinaries();
 
             _ = new Http();
@@ -155,7 +156,12 @@ namespace TwitchClipGrabber
 
             int num = 0;
             int.TryParse(tokens.Last(), out num);
-            return Path.Combine(dir, tokens.First() + '(' + (++num + 1) + ')' + ext);
+            string newPath;
+            do
+            {
+                newPath = Path.Combine(dir, tokens.First() + '(' + (++num + 1) + ')' + ext);
+            } while (File.Exists(newPath));
+            return newPath;
         }
     }
 }

--- a/Twitch Clip Grabber/Program.cs
+++ b/Twitch Clip Grabber/Program.cs
@@ -18,6 +18,7 @@ namespace TwitchClipGrabber
         private static YoutubeDL clipDownloader = new();
         private static Queue<Clip> downloadQueue = new();
         private static Queue<string> pathsQueue = new();
+        private static List<string> failedDownloads = new();
         private static bool _isDownloading;
         public static bool isDownloading
         {
@@ -112,7 +113,11 @@ namespace TwitchClipGrabber
                     Output = outputPath
                 }
             );
-            // TODO success check
+            if (!response.Success)
+            {
+                failedDownloads.Add(String.Format("\"{0}\" by {1} (at {2})",
+                        current.title, current.creator_name, TimeSpan.FromSeconds((double)current.vod_offset)));
+            }
 
             if (downloadQueue.Count > 1)
             {
@@ -131,6 +136,18 @@ namespace TwitchClipGrabber
                     form1.progressBar.Value = 0;
                     form1.progressBar.Visible = false;
                     form1.progressLabel.Text = "Download Completed";
+
+                    if (failedDownloads.Count > 0)
+                    {
+                        string message = String.Format("Download failed for {0} clip{1}:",
+                                failedDownloads.Count, failedDownloads.Count == 1 ? "" : "s");
+                        foreach (string c in failedDownloads)
+                        {
+                            message += "\n" + c;
+                        }
+                        MessageBox.Show(message);
+                        failedDownloads.Clear();
+                    }
                 }
             }
         }

--- a/Twitch Clip Grabber/Program.cs
+++ b/Twitch Clip Grabber/Program.cs
@@ -74,12 +74,29 @@ namespace TwitchClipGrabber
 
             if (isFirstDownload)
             {
-                isFirstDownload = false;
                 form1.progressBar.Value = 0;
                 form1.progressLabel.Text = "Downloading Dependencies";
-                await Utils.DownloadBinaries();
+                try
+                {
+                    await Utils.DownloadBinaries();
+                }
+                catch
+                {
+                    MessageBox.Show("Failed to download dependencies. Please download yt-dlp and ffmpeg yourself from their respective sites, and place the .exe files in the same folder as this tool!");
+                    return;
+                }
+
                 form1.progressLabel.Text = "Checking for Dependency Updates";
-                await clipDownloader.RunUpdate();
+                try
+                {
+                    await clipDownloader.RunUpdate();
+                }
+                catch
+                {
+                    // ignore exception - if the update fails, we can still try to download clips with the old version
+                }
+
+                isFirstDownload = false;
             }
 
             queueStartCount += queue.Count;

--- a/Twitch Clip Grabber/TwitchClipGrabber.csproj
+++ b/Twitch Clip Grabber/TwitchClipGrabber.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -31,6 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1293.44" />
+    <PackageReference Include="YoutubeDLSharp" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi! Heard Barry mention this tool being broken in the last VOD - this PR changes the clip downloader to use [yt-dlp](https://github.com/yt-dlp/yt-dlp/), which means it'll be usable again. (There's also a few other small changes to handle some errors.)

Downloading the required binaries and interfacing with them is handled via the [YoutubeDLSharp](https://github.com/Bluegrams/YoutubeDLSharp) package. If the user clicks on the "Download" button to grab clips, it'll automatically check the dependencies first and update them if neccessary, then start the download as usual.

A few small things to consider:
- Obviously, this PR is adding a dependency - but I feel it's a fair one, since yt-dlp is an extremely active project. So if Twitch ever changes something about the clip download process again, it'll probably be fixed quickly there, and then downloaded as an update here instead of having to do a new release.
- The download size display in the progress bar label does not work anymore - yt-dlp cannot check size before the download for Twitch clips, so I just removed that part.
- Right now, dependencies are always downloaded, and stored in the same folder as the tool. Being able to set the download location (or pointing the tool to an existing .exe, if the user already downloaded them somewhere else before) would be helpful - sadly, I have no idea how to use or work with WPF, so I haven't done anything in that regard. It is more of a "nice-to-have" than a "must-have", though.